### PR TITLE
Fix: Error when setting table_name with inherit=True

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -100,6 +100,7 @@ Authors
 - Michael England
 - Miguel Vargas
 - Mike Spainhower
+- Muneeb Shahid (`muneeb706 <https://github.com/muneeb706>` _)
 - Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
 - Nianpeng Li
 - Nick Träger

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
   ``SIMPLE_HISTORY_ENFORCE_HISTORY_MODEL_PERMISSIONS`` is set to ``True``
   in ``settings`` (gh-1017).
 - Fixed ``SimpleHistoryAdmin`` not properly integrating with custom user models (gh-1177)
+- Fixed error when setting ``table_name`` with ``inherit=True`` (gh-1195)
 
 3.3.0 (2023-03-08)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -298,7 +298,7 @@ class HistoricalRecords:
         attrs.update(self.get_extra_fields(model, fields))
         # type in python2 wants str as a first argument
         attrs.update(Meta=type("Meta", (), self.get_meta_options(model)))
-        if self.table_name is not None:
+        if not inherited and self.table_name is not None:
             attrs["Meta"].db_table = self.table_name
 
         # Set as the default then check for overrides


### PR DESCRIPTION
Error was thrown when `table_name` is set with inherit=True in base model.
inherited check added in the condition where `table_name` is checked for updating db table name. 

## Description

inherited flag argument in `create_history_model` method is used in the condition where `table_name` is checked. Condition at line 301 of `simple_history.models` now look like this:
`if not inherited and self.table_name is not None:`

## Related Issue
#1195

## Motivation and Context
I found this issue while looking for the solution of #1174.
In documentation it is not mentioned that table_name can't be used with inherit. It is implied that this should work, this inconsistency was the motivation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
